### PR TITLE
Move array-shuffle and nice-color-palettes to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     ]
   },
   "dependencies": {
-    "array-shuffle": "^1.0.1",
     "layout-bmfont-text": "^1.2.0",
-    "nice-color-palettes": "^3.0.0",
     "quad-indices": "^2.0.1"
   },
   "devDependencies": {
+    "array-shuffle": "^1.0.1",
     "bluebird": "^3.7.2",
     "browserify": "^16.5.1",
     "budo": "^11.6.3",
@@ -28,6 +27,7 @@
     "glsl-noise": "0.0.0",
     "glslify": "^7.0.0",
     "load-bmfont": "^1.0.0",
+    "nice-color-palettes": "^4.0.0",
     "standard": "^16.0.4",
     "sun-tzu-quotes": "^1.0.0",
     "three": "^0.131.1",


### PR DESCRIPTION
Replaces #3 
Move array-shuffle and nice-color-palettes to devDependencies so we can update aframe to use a new commit hash to get rid of 
```
got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
No fix available
node_modules/got
  nice-color-palettes  3.0.0
  Depends on vulnerable versions of got
  node_modules/nice-color-palettes
    three-bmfont-text  >=3.0.0
    Depends on vulnerable versions of nice-color-palettes
    node_modules/three-bmfont-text
```
reported by `npm audit`

@dmarcos can you please update the commit hash here
https://github.com/aframevr/aframe/blob/bc196800e708c86cf1b711ff139af3fa3ee5fa60/package.json#L54
after you merge, thanks!

Optional, you can remove package-lock.json in this repo and run again npm install and commit the new file to reduce the vulnerability count of dev dependencies.